### PR TITLE
fix typo on homepage

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -185,7 +185,7 @@ const Home: FunctionComponent<HomeProps> = ({featuredScripts, release}) => {
             <h3 className="text-3xl font-bold">Learn more</h3>
             <div className="pt-4 prose">
               <p>
-                Script Kit includes a built-in tutoria and myriad examples are
+                Script Kit includes a built-in tutorial and myriad examples are
                 avaiable on our discussions pages:
               </p>
             </div>


### PR DESCRIPTION
I discovered Script Kit by twitter, and I'm very interested to use it in my daily routine. However, I found a teeny-tiny typo in the [web page](https://www.scriptkit.com/). Thanks!

![image](https://user-images.githubusercontent.com/34333555/116141421-388a5200-a70b-11eb-9bd6-686a6b0911e4.png)


