### PR TITLE
bugfix: change community examples link to point to 'share' category

### DIFF
--- a/src/pages/index.tsx
+++ b/src/pages/index.tsx
@@ -44,7 +44,7 @@ type HomeProps = {
 const links = [
   {
     label: 'Community examples',
-    url: 'https://github.com/johnlindquist/kit/discussions/categories/show-and-tell',
+    url: 'https://github.com/johnlindquist/kit/discussions/categories/share',
   },
   {
     label: 'Quick orientation guide',


### PR DESCRIPTION
I've been enjoying messing around with ScriptKit. I noticed that the link to the community examples didn't actually show any examples, so this tiny PR attempts to fix that